### PR TITLE
fix(AG-0): Update to specify releases URL

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -92,7 +92,8 @@ runs:
 
         UPWIND_AGENT="shiftleft"
         AGENT_OUTPUT="${{ github.workspace }}/$UPWIND_AGENT"
-        UPWIND_AGENT_URL="https://releases.${{ inputs.upwind_uri }}/$UPWIND_AGENT/stable/$OS/$ARCH/$UPWIND_AGENT-$OS-$ARCH"
+        # All binaries are pulled from US
+        UPWIND_AGENT_URL="https://releases.upwind.io/$UPWIND_AGENT/stable/$OS/$ARCH/$UPWIND_AGENT-$OS-$ARCH"
 
         echo "Downloading from $UPWIND_AGENT_URL"
         curl -fsS -H "Authorization: Bearer $TOKEN" -L "$UPWIND_AGENT_URL" -o "$AGENT_OUTPUT"


### PR DESCRIPTION
All binaries are downloaded from US regardless of data sovereignty. Update to always pull from here. 

We are aware that this means that we cannot specify to pull from the Dev account, but this is a seldom used use case at this point and we want to get this fix out to a customer