### PR TITLE
fix(AG-3675): pull binaries from US

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -130,7 +130,7 @@ runs:
         UPWIND_AGENT="shiftleft"
         AGENT_OUTPUT="${{ github.workspace }}/$UPWIND_AGENT"
         # All binaries are pulled from US
-        UPWIND_AGENT_URL="https://releases.${{ inputs.upwind_uri }}/$UPWIND_AGENT/stable/$OS/$ARCH/$UPWIND_AGENT-$OS-$ARCH"
+        UPWIND_AGENT_URL="https://releases.upwind.io/$UPWIND_AGENT/stable/$OS/$ARCH/$UPWIND_AGENT-$OS-$ARCH"
 
         echo "Downloading from $UPWIND_AGENT_URL"
         curl -fsS -H "Authorization: Bearer $TOKEN" -L "$UPWIND_AGENT_URL" -o "$AGENT_OUTPUT"


### PR DESCRIPTION
### Description
Looks like releases eu region is not valid 

I think this was changed in error in this PR changeset:
https://github.com/upwindsecurity/shiftleft-create-image-scan-event-action/commit/8f67108ca3d863c018572805a6b4e364dc9223d2

Putting it back to the previous value where its hardcoded to use upwind.io directly