### PR TITLE
chore: upgrade actions/checkout and semantic-release-action to v6

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Execute Upwind CI scan plugin
         uses: ./
         with:

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
 
       - name: Set Up Docker Buildx
         uses: docker/setup-buildx-action@v1


### PR DESCRIPTION
## Summary
- Upgrade `actions/checkout` to v6 (latest: v6.0.2)
- Upgrade `cycjimmy/semantic-release-action` to v6 (latest: v6.0.0)

## Why
Keep GitHub Actions dependencies up to date for security patches and new features.

## Changes
Automated find-and-replace across all workflow files in this repo.
