### PR TITLE
feat(UP-0): add main_branch input to diff image scans vs base branch

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -70,10 +70,10 @@ inputs:
     type: boolean
   main_branch:
     description: >-
-      Base/target branch to diff against (e.g. the PR's base branch, such as
-      ${{ github.event.pull_request.base.ref }}). When set, introduced/resolved
-      CVEs are computed vs the latest scanned image of this branch instead of
-      the previously scanned image. Requires that branch to have been scanned.
+      Base/target branch to diff against (e.g. the PR's base branch, typically
+      github.event.pull_request.base.ref). When set, introduced/resolved CVEs
+      are computed vs the latest scanned image of this branch instead of the
+      previously scanned image. Requires that branch to have been scanned.
     required: false
   pr_id:
     description: Pull request identifier associated with the scan (optional)

--- a/action.yml
+++ b/action.yml
@@ -68,6 +68,19 @@ inputs:
     description: Enable debug logging
     default: false
     type: boolean
+  main_branch:
+    description: >-
+      Base/target branch to diff against (e.g. the PR's base branch, such as
+      ${{ github.event.pull_request.base.ref }}). When set, introduced/resolved
+      CVEs are computed vs the latest scanned image of this branch instead of
+      the previously scanned image. Requires that branch to have been scanned.
+    required: false
+  pr_id:
+    description: Pull request identifier associated with the scan (optional)
+    required: false
+  pr_link:
+    description: Pull request URL associated with the scan (optional)
+    required: false
   block_on:
     description: Block workflow based on Upwind Scan Recommendation. Can be either 'do_not_deploy' or 'deploy_with_caution'
 
@@ -159,7 +172,21 @@ runs:
         if [ "${{ inputs.use_sudo }}" = "true" ]; then
           SUDO=sudo
         fi
-  
+
+        # Optional base-branch diff args. Only added when provided, so the
+        # command stays compatible with shiftleft binaries that predate these
+        # flags (they are passed only when the user opts in via main_branch).
+        EXTRA_ARGS=()
+        if [ -n "${{ inputs.main_branch }}" ]; then
+          EXTRA_ARGS+=(--main-branch="${{ inputs.main_branch }}")
+        fi
+        if [ -n "${{ inputs.pr_id }}" ]; then
+          EXTRA_ARGS+=(--pr-id="${{ inputs.pr_id }}")
+        fi
+        if [ -n "${{ inputs.pr_link }}" ]; then
+          EXTRA_ARGS+=(--pr-link="${{ inputs.pr_link }}")
+        fi
+
         $SUDO ./shiftleft image \
           --source=GITHUB_ACTIONS \
           --initiator=${GITHUB_TRIGGERING_ACTOR} \
@@ -178,7 +205,8 @@ runs:
           --output-json=$OUTPUT_JSON \
           --oci-client=${{ inputs.oci_client }} \
           --block-on="${{ inputs.block_on}}" \
-          --should-perform-multi-platform-scan=${{ inputs.perform_multiarchitecture_image_scan}}
+          --should-perform-multi-platform-scan=${{ inputs.perform_multiarchitecture_image_scan}} \
+          "${EXTRA_ARGS[@]}"
         if [ ! -f "$OUTPUT_JSON" ]; then
           echo "Error: $OUTPUT_JSON not found"
           exit 1


### PR DESCRIPTION
## What
Adds optional `main_branch` (+ `pr_id` / `pr_link`) inputs. When `main_branch` is set, the action passes `--main-branch` (etc.) to the `shiftleft` binary so **introduced/resolved CVEs are computed vs the latest scanned image of the base branch** instead of the previous commit's image.

```yaml
- uses: upwindsecurity/shiftleft-create-image-scan-event-action@main
  with:
    ...
    main_branch: ${{ github.event.pull_request.base.ref }}
    pr_id: ${{ github.event.pull_request.number }}
```

## Safe by default
Flags are appended only when the inputs are non-empty (via a bash `EXTRA_ARGS` array). With no `main_branch`, nothing changes and the command is unchanged — so this is compatible with shiftleft binaries that predate the flags.

## Dependencies / ordering
- **Blocked on** upwindsecurity/shiftleft#243 (adds `--main-branch`/`--pr-id`/`--pr-link`) being merged **and a new binary released** before `main_branch` is actually used. Until then, leaving `main_branch` unset is a no-op.
- Requires the **base branch to have been scanned** (e.g. an `on: push: [main]` workflow) so a baseline image summary exists; otherwise the scan is treated as first-seen (all CVEs introduced).

## Verification
- `action.yml` is valid YAML.
- `EXTRA_ARGS` logic verified under `bash -eo pipefail`: empty inputs → no args; set inputs → correct `--main-branch=…`/`--pr-id=…`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)