### PR TITLE
feat(UP-0): diff-vs-main PR comment (introduced/resolved + total, vs base branch)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -164,6 +164,7 @@ runs:
         OUTPUT_JSON: ${{ inputs.output_json }}
       run: |
         echo "Running Upwind Scan"
+        SCAN_START=$(date +%s)
         COMMIT_SHA=${GITHUB_SHA}
         if [[ -n "${{ inputs.commit_sha }}" ]]; then
           COMMIT_SHA=${{ inputs.commit_sha }}
@@ -213,6 +214,15 @@ runs:
         fi
 
         echo "Info: Image scan completed"
+
+        # Human-readable scan duration for the PR comment footer.
+        SCAN_ELAPSED=$(( $(date +%s) - SCAN_START ))
+        if [ "$SCAN_ELAPSED" -ge 60 ]; then
+          SCAN_DURATION_HUMAN="$((SCAN_ELAPSED / 60))m $((SCAN_ELAPSED % 60))s"
+        else
+          SCAN_DURATION_HUMAN="${SCAN_ELAPSED}s"
+        fi
+        echo "SCAN_DURATION_HUMAN=${SCAN_DURATION_HUMAN}" >> "$GITHUB_ENV"
     - name: Comment on PR (conditional)
       shell: bash
       env:
@@ -222,6 +232,7 @@ runs:
         ADD_COMMENT: ${{ inputs.add_comment }}
         OUTPUT_JSON: ${{ inputs.output_json }}
         MAIN_BRANCH: ${{ inputs.main_branch }}
+        UPWIND_URI: ${{ inputs.upwind_uri }}
       run: |
         if [ "$ADD_COMMENT" != "true" ]; then
           echo "Info: Skipping comment"
@@ -357,6 +368,14 @@ runs:
             emit_table "$RESOLVED" "✅ <strong>Resolved</strong> · ${R} finding${rsfx}" "0"
           fi
         done < <(jq -c '.[]' "$ARRAY")
+
+        # Footer: link to the full analysis in the Upwind Console + scan time.
+        if [ -n "$FINGERPRINT" ]; then
+          COMMENT+="[View full analysis in Upwind Console →](https://console.${UPWIND_URI:-upwind.io}/code?mainPageTab=Reviews&secondaryTab=SCA&sidePanel=scan-at-build&sidePanelItemId=${FINGERPRINT})"$'\n\n'
+        fi
+        if [ -n "${SCAN_DURATION_HUMAN:-}" ]; then
+          COMMENT+="_Scan completed in ${SCAN_DURATION_HUMAN}_"$'\n'
+        fi
 
         # Final hard safety net: never exceed GitHub's 65536-char limit.
         if [ "${#COMMENT}" -gt 65000 ]; then

--- a/action.yml
+++ b/action.yml
@@ -153,7 +153,7 @@ runs:
         else
           RELEASE_BUCKET="releases.upwind.io"
         fi
-        UPWIND_AGENT_URL="https://$RELEASE_BUCKET/$UPWIND_AGENT/vsmain-test/$OS/$ARCH/$UPWIND_AGENT-$OS-$ARCH"  # TEST ONLY: dev binary built from shiftleft#243
+        UPWIND_AGENT_URL="https://$RELEASE_BUCKET/$UPWIND_AGENT/stable/$OS/$ARCH/$UPWIND_AGENT-$OS-$ARCH"
 
         echo "Downloading from $UPWIND_AGENT_URL"
         curl -fsS -H "Authorization: Bearer $TOKEN" -L "$UPWIND_AGENT_URL" -o "$AGENT_OUTPUT"

--- a/action.yml
+++ b/action.yml
@@ -70,10 +70,10 @@ inputs:
     type: boolean
   main_branch:
     description: >-
-      Base/target branch to diff against (e.g. the PR's base branch, such as
-      ${{ github.event.pull_request.base.ref }}). When set, introduced/resolved
-      CVEs are computed vs the latest scanned image of this branch instead of
-      the previously scanned image. Requires that branch to have been scanned.
+      Base/target branch to diff against (e.g. the PR's base branch, typically
+      github.event.pull_request.base.ref). When set, introduced/resolved CVEs
+      are computed vs the latest scanned image of this branch instead of the
+      previously scanned image. Requires that branch to have been scanned.
     required: false
   pr_id:
     description: Pull request identifier associated with the scan (optional)

--- a/action.yml
+++ b/action.yml
@@ -68,6 +68,19 @@ inputs:
     description: Enable debug logging
     default: false
     type: boolean
+  main_branch:
+    description: >-
+      Base/target branch to diff against (e.g. the PR's base branch, such as
+      ${{ github.event.pull_request.base.ref }}). When set, introduced/resolved
+      CVEs are computed vs the latest scanned image of this branch instead of
+      the previously scanned image. Requires that branch to have been scanned.
+    required: false
+  pr_id:
+    description: Pull request identifier associated with the scan (optional)
+    required: false
+  pr_link:
+    description: Pull request URL associated with the scan (optional)
+    required: false
   block_on:
     description: Block workflow based on Upwind Scan Recommendation. Can be either 'do_not_deploy' or 'deploy_with_caution'
 
@@ -159,7 +172,21 @@ runs:
         if [ "${{ inputs.use_sudo }}" = "true" ]; then
           SUDO=sudo
         fi
-  
+
+        # Optional base-branch diff args. Only added when provided, so the
+        # command stays compatible with shiftleft binaries that predate these
+        # flags (they are passed only when the user opts in via main_branch).
+        EXTRA_ARGS=()
+        if [ -n "${{ inputs.main_branch }}" ]; then
+          EXTRA_ARGS+=(--main-branch="${{ inputs.main_branch }}")
+        fi
+        if [ -n "${{ inputs.pr_id }}" ]; then
+          EXTRA_ARGS+=(--pr-id="${{ inputs.pr_id }}")
+        fi
+        if [ -n "${{ inputs.pr_link }}" ]; then
+          EXTRA_ARGS+=(--pr-link="${{ inputs.pr_link }}")
+        fi
+
         $SUDO ./shiftleft image \
           --source=GITHUB_ACTIONS \
           --initiator=${GITHUB_TRIGGERING_ACTOR} \
@@ -178,7 +205,8 @@ runs:
           --output-json=$OUTPUT_JSON \
           --oci-client=${{ inputs.oci_client }} \
           --block-on="${{ inputs.block_on}}" \
-          --should-perform-multi-platform-scan=${{ inputs.perform_multiarchitecture_image_scan}}
+          --should-perform-multi-platform-scan=${{ inputs.perform_multiarchitecture_image_scan}} \
+          "${EXTRA_ARGS[@]}"
         if [ ! -f "$OUTPUT_JSON" ]; then
           echo "Error: $OUTPUT_JSON not found"
           exit 1

--- a/action.yml
+++ b/action.yml
@@ -370,8 +370,8 @@ runs:
         done < <(jq -c '.[]' "$ARRAY")
 
         # Footer: link to the full analysis in the Upwind Console + scan time.
-        if [ -n "$FINGERPRINT" ]; then
-          COMMENT+="[View full analysis in Upwind Console →](https://console.${UPWIND_URI:-upwind.io}/code?mainPageTab=Reviews&secondaryTab=SCA&sidePanel=scan-at-build&sidePanelItemId=${FINGERPRINT})"$'\n\n'
+        if [ -n "$IMAGE_VERSION" ] && [ "$IMAGE_VERSION" != "unknown" ]; then
+          COMMENT+="[View full analysis in Upwind Console →](https://console.${UPWIND_URI:-upwind.io}/vulnerabilities?mainPageTab=Shift%20left&sidePanel=scan-at-build&sidePanelItemId=${IMAGE_VERSION})"$'\n\n'
         fi
         if [ -n "${SCAN_DURATION_HUMAN:-}" ]; then
           COMMENT+="_Scan completed in ${SCAN_DURATION_HUMAN}_"$'\n'

--- a/action.yml
+++ b/action.yml
@@ -225,13 +225,13 @@ runs:
         # the limit (per-arch summaries are always kept). TRUNCATED ensures the
         # "truncated" note is added at most once.
         MAX_ROWS=60
-        COMMENT_BUDGET=44000
+        COMMENT_BUDGET=60000
         TRUNCATED=0
 
         # Append one severity table (heading + rows) for the current arch's
         # $CVES to $COMMENT, honouring the size budget. $1 = CRITICAL|HIGH|OTHER.
         build_table() {
-          local sev="$1" total rows heading collapse=0
+          local sev="$1" total rows heading collapse=0 buf=""
           case "$sev" in
             CRITICAL) heading=$'### Critical severity'; total="$C" ;;
             HIGH)     heading=$'### High severity'; total="$H" ;;
@@ -239,18 +239,7 @@ runs:
           esac
           [ "${total:-0}" -eq 0 ] && return 0
 
-          # Size guard: keep the per-arch summaries, drop detail tables once we
-          # are near the limit, and say so once.
-          if [ "${#COMMENT}" -gt "$COMMENT_BUDGET" ]; then
-            if [ "$TRUNCATED" -ne 1 ]; then
-              COMMENT+=$'_Detailed CVE tables were truncated to stay within GitHub\'s comment size limit — see the full list in the Upwind Console._\n\n'
-              TRUNCATED=1
-            fi
-            return 0
-          fi
-
           if [ "$collapse" -eq 1 ]; then
-            # Everything not CRITICAL/HIGH (MEDIUM/LOW/UNKNOWN)
             rows=$(echo "$CVES" | jq -r --argjson max "$MAX_ROWS" '
               [.[] | select(((.severity // "" | ascii_upcase)!="CRITICAL") and ((.severity // "" | ascii_upcase)!="HIGH"))][0:$max][]
               | [ (.cveId // .cveName // "<unknown>"),
@@ -267,23 +256,35 @@ runs:
           fi
           [ -z "$rows" ] && return 0
 
+          # Build into a local buffer so we can measure before appending.
           if [ "$collapse" -eq 1 ]; then
-            COMMENT+="<details><summary><strong>Other severities</strong> (Medium/Low/Unknown) — \`$OTHER\` CVEs</summary>"$'\n\n'
+            buf+="<details><summary><strong>Other severities</strong> (Medium/Low/Unknown) — \`$OTHER\` CVEs</summary>"$'\n\n'
           else
-            COMMENT+="$heading"$'\n\n'
+            buf+="$heading"$'\n\n'
           fi
-          COMMENT+=$'| CVE | Description | Package |\n'
-          COMMENT+=$'|---|---|---|\n'
+          buf+=$'| CVE | Description | Package |\n'
+          buf+=$'|---|---|---|\n'
           while IFS=$'\t' read -r CVE DESC PKG; do
             [ -z "${CVE}" ] && CVE="<unknown>"
             [ -z "${PKG}" ] && PKG="<pkg>"
-            COMMENT+="| ${CVE} | ${DESC} | ${PKG} |"$'\n'
+            buf+="| ${CVE} | ${DESC} | ${PKG} |"$'\n'
           done <<< "$rows"
           if [ "$total" -gt "$MAX_ROWS" ]; then
-            COMMENT+="_…and $((total - MAX_ROWS)) more — see the full list in the Upwind Console._"$'\n'
+            buf+="_…and $((total - MAX_ROWS)) more — see the full list in the Upwind Console._"$'\n'
           fi
-          [ "$collapse" -eq 1 ] && COMMENT+=$'</details>\n'
-          COMMENT+=$'\n'
+          [ "$collapse" -eq 1 ] && buf+=$'</details>\n'
+          buf+=$'\n'
+
+          # Size guard: only append this table if it fits within the budget.
+          if [ $((${#COMMENT} + ${#buf})) -gt "$COMMENT_BUDGET" ]; then
+            if [ "$TRUNCATED" -ne 1 ]; then
+              COMMENT+=$'_Detailed CVE tables were truncated to stay within GitHub\'s comment size limit — see the full list in the Upwind Console._\n\n'
+              TRUNCATED=1
+            fi
+            return 0
+          fi
+
+          COMMENT+="$buf"
         }
 
         # Loop through each architecture
@@ -328,9 +329,19 @@ runs:
           COMMENT+=$'</details>'$'\n'
         fi
 
-        # Final hard safety net: never exceed GitHub's 65536-char comment limit.
+        # Final hard safety net: never exceed GitHub's 65536-char limit.
+        # Truncate at a newline boundary and close any unclosed <details> tags
+        # so the PR comment renders valid markdown.
         if [ "${#COMMENT}" -gt 65000 ]; then
-          COMMENT="${COMMENT:0:64500}"$'\n\n_Comment truncated to fit GitHub\'s size limit — see the full results in the Upwind Console._'
+          COMMENT="${COMMENT:0:64500}"
+          COMMENT="${COMMENT%$'\n'*}"
+          OPEN_TAGS=$(grep -c '<details>' <<< "$COMMENT" || true)
+          CLOSE_TAGS=$(grep -c '</details>' <<< "$COMMENT" || true)
+          while [ "$OPEN_TAGS" -gt "$CLOSE_TAGS" ]; do
+            COMMENT+=$'\n</details>'
+            CLOSE_TAGS=$((CLOSE_TAGS + 1))
+          done
+          COMMENT+=$'\n\n_Comment truncated to fit GitHub\'s size limit — see the full results in the Upwind Console._'
         fi
 
         echo "Posting summary comment on PR"
@@ -347,3 +358,4 @@ runs:
           -H "X-GitHub-Api-Version: 2022-11-28" \
           --data @"$PAYLOAD_FILE" \
           "https://api.github.com/repos/$REPO/issues/$PR_NUMBER/comments"
+        rm -f "$PAYLOAD_FILE"

--- a/action.yml
+++ b/action.yml
@@ -325,6 +325,7 @@ runs:
 
         while IFS= read -r scan; do
           ARCH=$(echo "$scan" | jq -r '.arch? // ""')
+          STATUS=$(echo "$scan" | jq -r '.scanStatus // ""')
           INTRO=$(echo "$scan" | jq -c '.introducedCves // []')
           RESOLVED=$(echo "$scan" | jq -c '.resolvedCves // []')
           PRESENT=$(echo "$scan" | jq -c '(.introducedCves // []) + (.noChangeCves // [])')
@@ -338,8 +339,15 @@ runs:
           cL=$(echo "$PRESENT" | jq '[.[] | select((.severity // "" | ascii_upcase)=="LOW")] | length')
           cU=$(echo "$PRESENT" | jq '[.[] | select((.severity // "" | ascii_upcase) as $s | ($s!="CRITICAL" and $s!="HIGH" and $s!="MEDIUM" and $s!="LOW"))] | length')
 
-          if [ "$ARCH_COUNT" -gt 1 ] && [ -n "$ARCH" ]; then
-            COMMENT+="## $ARCH"$'\n\n'
+          # Per-arch header + status.
+          if [ -n "$ARCH" ]; then
+            COMMENT+="## $ARCH"$'\n'
+          fi
+          if [ -n "$STATUS" ]; then
+            COMMENT+="- **Status:** \`$STATUS\`"$'\n'
+          fi
+          if [ -n "$ARCH" ] || [ -n "$STATUS" ]; then
+            COMMENT+=$'\n'
           fi
 
           # Summary line: counts only (introduced / resolved / total present).

--- a/action.yml
+++ b/action.yml
@@ -164,6 +164,7 @@ runs:
         OUTPUT_JSON: ${{ inputs.output_json }}
       run: |
         echo "Running Upwind Scan"
+        SCAN_START=$(date +%s)
         COMMIT_SHA=${GITHUB_SHA}
         if [[ -n "${{ inputs.commit_sha }}" ]]; then
           COMMIT_SHA=${{ inputs.commit_sha }}
@@ -213,6 +214,15 @@ runs:
         fi
 
         echo "Info: Image scan completed"
+
+        # Record human-readable scan duration for the PR comment.
+        SCAN_ELAPSED=$(( $(date +%s) - SCAN_START ))
+        if [ "$SCAN_ELAPSED" -ge 60 ]; then
+          SCAN_DURATION_HUMAN="$((SCAN_ELAPSED / 60))m $((SCAN_ELAPSED % 60))s"
+        else
+          SCAN_DURATION_HUMAN="${SCAN_ELAPSED}s"
+        fi
+        echo "SCAN_DURATION_HUMAN=${SCAN_DURATION_HUMAN}" >> "$GITHUB_ENV"
     - name: Comment on PR (conditional)
       shell: bash
       env:
@@ -221,6 +231,8 @@ runs:
         PR_NUMBER: ${{ inputs.pr_number }}
         ADD_COMMENT: ${{ inputs.add_comment }}
         OUTPUT_JSON: ${{ inputs.output_json }}
+        UPWIND_URI: ${{ inputs.upwind_uri }}
+        MAIN_BRANCH: ${{ inputs.main_branch }}
       run: |
         if [ "$ADD_COMMENT" != "true" ]; then
           echo "Info: Skipping comment"
@@ -232,134 +244,124 @@ runs:
           exit 1
         fi
 
-        # Normalise JSON
+        # Normalise the scan output (stream of objects) into a JSON array.
         ARRAY="$(mktemp)"
-
-        # Create an array from stream of valid json objects
         jq -cs 'if type=="array" then . else [.] end' "$OUTPUT_JSON" > "$ARRAY"
 
-        CLEAN_ARCHES=""
+        # If the backend wasn't ready and returned no usable data, skip the
+        # comment rather than posting an "unknown:unknown" placeholder.
+        if [ "$(jq '[.[] | select((.imageName // "") != "")] | length' "$ARRAY")" -eq 0 ]; then
+          echo "Warning: scan results not ready (empty output); skipping comment"
+          exit 0
+        fi
 
-        # Build base comment
         IMAGE_NAME=$(jq -r '.[0].imageName // "unknown"' "$ARRAY")
         IMAGE_VERSION=$(jq -r '.[0].imageVersion // "unknown"' "$ARRAY")
+        FINGERPRINT=$(jq -r '.[0].fingerprint // ""' "$ARRAY")
+        ARCH_COUNT=$(jq 'length' "$ARRAY")
+
+        # Label for what the diff is computed against.
+        if [ -n "$MAIN_BRANCH" ]; then
+          BASE_LABEL="\`${MAIN_BRANCH#refs/heads/}\`"
+        else
+          BASE_LABEL="the previous scan"
+        fi
+
+        MAX_ROWS=60
 
         COMMENT="# 🏄‍♂️ Upwind Image Scan Report"$'\n'
         COMMENT+="**Image:** \`$IMAGE_NAME:$IMAGE_VERSION\`"$'\n\n'
 
-        # Caps that keep the comment under GitHub's 65536-char limit even for
-        # multi-arch, vulnerability-heavy images. MAX_ROWS bounds each severity
-        # table; COMMENT_BUDGET stops adding detail tables once we're close to
-        # the limit (per-arch summaries are always kept). TRUNCATED ensures the
-        # "truncated" note is added at most once.
-        MAX_ROWS=60
-        COMMENT_BUDGET=60000
-        TRUNCATED=0
-
-        # Append one severity table (heading + rows) for the current arch's
-        # $CVES to $COMMENT, honouring the size budget. $1 = CRITICAL|HIGH|OTHER.
-        build_table() {
-          local sev="$1" total rows heading collapse=0 buf=""
-          case "$sev" in
-            CRITICAL) heading=$'### Critical severity'; total="$C" ;;
-            HIGH)     heading=$'### High severity'; total="$H" ;;
-            OTHER)    collapse=1; total="$OTHER" ;;
-          esac
-          [ "${total:-0}" -eq 0 ] && return 0
-
-          if [ "$collapse" -eq 1 ]; then
-            rows=$(echo "$CVES" | jq -r --argjson max "$MAX_ROWS" '
-              [.[] | select(((.severity // "" | ascii_upcase)!="CRITICAL") and ((.severity // "" | ascii_upcase)!="HIGH"))][0:$max][]
-              | [ (.cveId // .cveName // "<unknown>"),
-                  ((.cveDescription // "") | gsub("\\|";"\\\\|") | gsub("`";"\\\\`") | gsub("<";"&lt;") | gsub(">";"&gt;") | gsub("\r?\n";" ") | .[0:240]),
-                  ((.packageName // "<pkg>") + " " + (.packageVersion // "")) ]
-              | @tsv')
-          else
-            rows=$(echo "$CVES" | jq -r --arg sev "$sev" --argjson max "$MAX_ROWS" '
-              [.[] | select((.severity // "" | ascii_upcase)==$sev)][0:$max][]
-              | [ (.cveId // .cveName // "<unknown>"),
-                  ((.cveDescription // "") | gsub("\\|";"\\\\|") | gsub("`";"\\\\`") | gsub("<";"&lt;") | gsub(">";"&gt;") | gsub("\r?\n";" ") | .[0:240]),
-                  ((.packageName // "<pkg>") + " " + (.packageVersion // "")) ]
-              | @tsv')
-          fi
-          [ -z "$rows" ] && return 0
-
-          # Build into a local buffer so we can measure before appending.
-          if [ "$collapse" -eq 1 ]; then
-            buf+="<details><summary><strong>Other severities</strong> (Medium/Low/Unknown) — \`$OTHER\` CVEs</summary>"$'\n\n'
-          else
-            buf+="$heading"$'\n\n'
-          fi
-          buf+=$'| CVE | Description | Package |\n'
-          buf+=$'|---|---|---|\n'
+        # Render a collapsible table of the given CVE JSON array (capped).
+        # $1=cves json  $2=summary line (already includes emoji/label/count)
+        emit_table() {
+          local cves_json="$1" summary="$2" rows
+          rows=$(echo "$cves_json" | jq -r --argjson max "$MAX_ROWS" '
+            [.[]][0:$max][]
+            | [ (.cveId // .cveName // "<unknown>"),
+                ((.cveDescription // "") | gsub("\\|";"\\\\|") | gsub("`";"\\\\`") | gsub("<";"&lt;") | gsub(">";"&gt;") | gsub("\r?\n";" ") | .[0:240]),
+                ((.packageName // "<pkg>") + " " + (.packageVersion // "")) ]
+            | @tsv')
+          local total
+          total=$(echo "$cves_json" | jq 'length')
+          COMMENT+="<details><summary>${summary}</summary>"$'\n\n'
+          COMMENT+=$'| CVE | Description | Package |\n|---|---|---|\n'
           while IFS=$'\t' read -r CVE DESC PKG; do
             [ -z "${CVE}" ] && CVE="<unknown>"
             [ -z "${PKG}" ] && PKG="<pkg>"
-            buf+="| ${CVE} | ${DESC} | ${PKG} |"$'\n'
+            COMMENT+="| ${CVE} | ${DESC} | ${PKG} |"$'\n'
           done <<< "$rows"
           if [ "$total" -gt "$MAX_ROWS" ]; then
-            buf+="_…and $((total - MAX_ROWS)) more — see the full list in the Upwind Console._"$'\n'
+            COMMENT+="_…and $((total - MAX_ROWS)) more — see the Upwind Console._"$'\n'
           fi
-          [ "$collapse" -eq 1 ] && buf+=$'</details>\n'
-          buf+=$'\n'
-
-          # Size guard: only append this table if it fits within the budget.
-          if [ $((${#COMMENT} + ${#buf})) -gt "$COMMENT_BUDGET" ]; then
-            if [ "$TRUNCATED" -ne 1 ]; then
-              COMMENT+=$'_Detailed CVE tables were truncated to stay within GitHub\'s comment size limit — see the full list in the Upwind Console._\n\n'
-              TRUNCATED=1
-            fi
-            return 0
-          fi
-
-          COMMENT+="$buf"
+          COMMENT+=$'</details>\n\n'
         }
 
-        # Loop through each architecture
+        # Introduced findings for one severity, as a collapsible section.
+        emit_introduced_sev() {
+          local intro_json="$1" sev="$2" emoji="$3" label="$4" n sfx
+          n=$(echo "$intro_json" | jq --arg s "$sev" '[.[] | select((.severity // "" | ascii_upcase)==$s)] | length')
+          [ "$n" -eq 0 ] && return 0
+          sfx="s"; if [ "$n" -eq 1 ]; then sfx=""; fi
+          emit_table "$(echo "$intro_json" | jq -c --arg s "$sev" '[.[] | select((.severity // "" | ascii_upcase)==$s)]')" \
+                     "${emoji} <strong>${label}</strong> · ${n} finding${sfx}"
+        }
+
         while IFS= read -r scan; do
           ARCH=$(echo "$scan" | jq -r '.arch? // ""')
-            [ -z "$ARCH" ] && ARCH="arch not specified"
-          STATUS=$(echo "$scan" | jq -r '.scanStatus // "unknown"')
+          INTRO=$(echo "$scan" | jq -c '.introducedCves // []')
+          RESOLVED=$(echo "$scan" | jq -c '.resolvedCves // []')
+          PRESENT=$(echo "$scan" | jq -c '(.introducedCves // []) + (.noChangeCves // [])')
 
-          # Full set of CVEs present in the image for this branch =
-          # newly introduced + already-present (no_change). This is the whole
-          # image, NOT just the diff vs the previously scanned image.
-          CVES=$(echo "$scan" | jq -c '(.introducedCves // []) + (.noChangeCves // [])')
+          N=$(echo "$INTRO" | jq 'length')
+          R=$(echo "$RESOLVED" | jq 'length')
+          T=$(echo "$PRESENT" | jq 'length')
+          cC=$(echo "$PRESENT" | jq '[.[] | select((.severity // "" | ascii_upcase)=="CRITICAL")] | length')
+          cH=$(echo "$PRESENT" | jq '[.[] | select((.severity // "" | ascii_upcase)=="HIGH")] | length')
+          cM=$(echo "$PRESENT" | jq '[.[] | select((.severity // "" | ascii_upcase)=="MEDIUM")] | length')
+          cL=$(echo "$PRESENT" | jq '[.[] | select((.severity // "" | ascii_upcase)=="LOW")] | length')
+          cU=$(echo "$PRESENT" | jq '[.[] | select((.severity // "" | ascii_upcase) as $s | ($s!="CRITICAL" and $s!="HIGH" and $s!="MEDIUM" and $s!="LOW"))] | length')
 
-          T=$(echo "$CVES" | jq 'length')
-          N=$(echo "$scan" | jq '(.introducedCves // []) | length')
-          O=$(echo "$scan" | jq '(.noChangeCves // []) | length')
-          R=$(echo "$scan" | jq '(.resolvedCves // []) | length')
-          H=$(echo "$CVES" | jq '[.[] | select((.severity // "" | ascii_upcase)=="HIGH")] | length')
-          C=$(echo "$CVES" | jq '[.[] | select((.severity // "" | ascii_upcase)=="CRITICAL")] | length')
-          OTHER=$(echo "$CVES" | jq '[.[] | select(((.severity // "" | ascii_upcase)!="CRITICAL") and ((.severity // "" | ascii_upcase)!="HIGH"))] | length')
-
-          if [ "$T" -eq 0 ]; then
-            CLEAN_ARCHES+="- \`$ARCH\` (status: \`$STATUS\`)"$'\n'
-            continue
+          if [ "$ARCH_COUNT" -gt 1 ] && [ -n "$ARCH" ]; then
+            COMMENT+="## $ARCH"$'\n\n'
           fi
 
-          # Per-arch summary (always shown — this is the whole-image picture)
-          COMMENT+="## $ARCH"$'\n'
-          COMMENT+="- **Status:** \`$STATUS\`"$'\n'
-          COMMENT+="- **Total CVEs in image:** \`$T\` (\`$N\` new since last scan · \`$O\` already present · \`$R\` resolved)"$'\n'
-          COMMENT+="- **Critical:** \`$C\`, **High:** \`$H\`, **Medium/Low/Other:** \`$OTHER\`"$'\n\n'
+          # Summary line: counts only (introduced / resolved / total present).
+          ivword="vulnerabilities"; if [ "$N" -eq 1 ]; then ivword="vulnerability"; fi
+          COMMENT+="**${N}** newly introduced ${ivword} · **${R}** resolved · **${T}** total in this PR vs ${BASE_LABEL}"$'\n'
 
-          build_table "CRITICAL"
-          build_table "HIGH"
-          build_table "OTHER"
+          # Severity breakdown of the total present (counts only, not listed).
+          BREAK=""
+          [ "$cC" -gt 0 ] && BREAK+="🔴 ${cC} Critical | "
+          [ "$cH" -gt 0 ] && BREAK+="🔶 ${cH} High | "
+          [ "$cM" -gt 0 ] && BREAK+="🟡 ${cM} Medium | "
+          [ "$cL" -gt 0 ] && BREAK+="🟢 ${cL} Low | "
+          [ "$cU" -gt 0 ] && BREAK+="⚪ ${cU} Other | "
+          BREAK="${BREAK% | }"
+          if [ -n "$BREAK" ]; then COMMENT+="$BREAK"$'\n'; fi
+          COMMENT+=$'\n'
+
+          # Detail tables: ONLY introduced (by severity) + resolved.
+          # The "total" / already-present CVEs are counted above but not listed.
+          emit_introduced_sev "$INTRO" "CRITICAL" "🔴" "Critical"
+          emit_introduced_sev "$INTRO" "HIGH"     "🔶" "High"
+          emit_introduced_sev "$INTRO" "MEDIUM"   "🟡" "Medium"
+          emit_introduced_sev "$INTRO" "LOW"      "🟢" "Low"
+          if [ "$R" -gt 0 ]; then
+            rsfx="s"; if [ "$R" -eq 1 ]; then rsfx=""; fi
+            emit_table "$RESOLVED" "✅ <strong>Resolved</strong> · ${R} finding${rsfx}"
+          fi
         done < <(jq -c '.[]' "$ARRAY")
 
-        # Collapsed list of totally clean arches (if any)
-        if [ -n "$CLEAN_ARCHES" ]; then
-          COMMENT+=$'<details><summary><strong>More architectures</strong> — all clear ✅</summary>'$'\n\n'
-          COMMENT+="$CLEAN_ARCHES"$'\n'
-          COMMENT+=$'</details>'$'\n'
+        # Console link + scan duration footer.
+        if [ -n "$FINGERPRINT" ]; then
+          COMMENT+="[View full analysis in Upwind Console](https://console.${UPWIND_URI:-upwind.io}/code?mainPageTab=Reviews&secondaryTab=SCA&sidePanel=scan-at-build&sidePanelItemId=${FINGERPRINT})"$'\n\n'
+        fi
+        if [ -n "${SCAN_DURATION_HUMAN:-}" ]; then
+          COMMENT+="_Scan completed in ${SCAN_DURATION_HUMAN}_"$'\n'
         fi
 
         # Final hard safety net: never exceed GitHub's 65536-char limit.
-        # Truncate at a newline boundary and close any unclosed <details> tags
-        # so the PR comment renders valid markdown.
         if [ "${#COMMENT}" -gt 65000 ]; then
           COMMENT="${COMMENT:0:64500}"
           COMMENT="${COMMENT%$'\n'*}"
@@ -369,14 +371,12 @@ runs:
             COMMENT+=$'\n</details>'
             CLOSE_TAGS=$((CLOSE_TAGS + 1))
           done
-          COMMENT+=$'\n\n_Comment truncated to fit GitHub\'s size limit — see the full results in the Upwind Console._'
+          COMMENT+=$'\n\n_Comment truncated to fit GitHub\'s size limit — see the Upwind Console._'
         fi
 
         echo "Posting summary comment on PR"
 
-        # Send the (potentially large) body via a file, never as a shell
-        # argument — a big --arg/-d would hit the OS arg-length limit
-        # ("Argument list too long") on multi-arch, CVE-heavy images.
+        # Send the body via a file, never as a shell argument.
         PAYLOAD_FILE="$(mktemp)"
         printf '%s' "$COMMENT" | jq -Rs '{ body: . }' > "$PAYLOAD_FILE"
         curl -L \

--- a/action.yml
+++ b/action.yml
@@ -219,10 +219,72 @@ runs:
         COMMENT="# 🏄‍♂️ Upwind Image Scan Report"$'\n'
         COMMENT+="**Image:** \`$IMAGE_NAME:$IMAGE_VERSION\`"$'\n\n'
 
-        # Max CVE rows rendered per severity table (keeps the comment under
-        # GitHub's 65536-char limit on vulnerability-heavy images). Remaining
-        # CVEs are summarised with a "see Upwind Console" note.
-        MAX_ROWS=80
+        # Caps that keep the comment under GitHub's 65536-char limit even for
+        # multi-arch, vulnerability-heavy images. MAX_ROWS bounds each severity
+        # table; COMMENT_BUDGET stops adding detail tables once we're close to
+        # the limit (per-arch summaries are always kept). TRUNCATED ensures the
+        # "truncated" note is added at most once.
+        MAX_ROWS=60
+        COMMENT_BUDGET=44000
+        TRUNCATED=0
+
+        # Append one severity table (heading + rows) for the current arch's
+        # $CVES to $COMMENT, honouring the size budget. $1 = CRITICAL|HIGH|OTHER.
+        build_table() {
+          local sev="$1" total rows heading collapse=0
+          case "$sev" in
+            CRITICAL) heading=$'### Critical severity'; total="$C" ;;
+            HIGH)     heading=$'### High severity'; total="$H" ;;
+            OTHER)    collapse=1; total="$OTHER" ;;
+          esac
+          [ "${total:-0}" -eq 0 ] && return 0
+
+          # Size guard: keep the per-arch summaries, drop detail tables once we
+          # are near the limit, and say so once.
+          if [ "${#COMMENT}" -gt "$COMMENT_BUDGET" ]; then
+            if [ "$TRUNCATED" -ne 1 ]; then
+              COMMENT+=$'_Detailed CVE tables were truncated to stay within GitHub\'s comment size limit — see the full list in the Upwind Console._\n\n'
+              TRUNCATED=1
+            fi
+            return 0
+          fi
+
+          if [ "$collapse" -eq 1 ]; then
+            # Everything not CRITICAL/HIGH (MEDIUM/LOW/UNKNOWN)
+            rows=$(echo "$CVES" | jq -r --argjson max "$MAX_ROWS" '
+              [.[] | select(((.severity // "" | ascii_upcase)!="CRITICAL") and ((.severity // "" | ascii_upcase)!="HIGH"))][0:$max][]
+              | [ (.cveId // .cveName // "<unknown>"),
+                  ((.cveDescription // "") | gsub("\\|";"\\\\|") | gsub("`";"\\\\`") | gsub("<";"&lt;") | gsub(">";"&gt;") | gsub("\r?\n";" ") | .[0:240]),
+                  ((.packageName // "<pkg>") + " " + (.packageVersion // "")) ]
+              | @tsv')
+          else
+            rows=$(echo "$CVES" | jq -r --arg sev "$sev" --argjson max "$MAX_ROWS" '
+              [.[] | select((.severity // "" | ascii_upcase)==$sev)][0:$max][]
+              | [ (.cveId // .cveName // "<unknown>"),
+                  ((.cveDescription // "") | gsub("\\|";"\\\\|") | gsub("`";"\\\\`") | gsub("<";"&lt;") | gsub(">";"&gt;") | gsub("\r?\n";" ") | .[0:240]),
+                  ((.packageName // "<pkg>") + " " + (.packageVersion // "")) ]
+              | @tsv')
+          fi
+          [ -z "$rows" ] && return 0
+
+          if [ "$collapse" -eq 1 ]; then
+            COMMENT+="<details><summary><strong>Other severities</strong> (Medium/Low/Unknown) — \`$OTHER\` CVEs</summary>"$'\n\n'
+          else
+            COMMENT+="$heading"$'\n\n'
+          fi
+          COMMENT+=$'| CVE | Description | Package |\n'
+          COMMENT+=$'|---|---|---|\n'
+          while IFS=$'\t' read -r CVE DESC PKG; do
+            [ -z "${CVE}" ] && CVE="<unknown>"
+            [ -z "${PKG}" ] && PKG="<pkg>"
+            COMMENT+="| ${CVE} | ${DESC} | ${PKG} |"$'\n'
+          done <<< "$rows"
+          if [ "$total" -gt "$MAX_ROWS" ]; then
+            COMMENT+="_…and $((total - MAX_ROWS)) more — see the full list in the Upwind Console._"$'\n'
+          fi
+          [ "$collapse" -eq 1 ] && COMMENT+=$'</details>\n'
+          COMMENT+=$'\n'
+        }
 
         # Loop through each architecture
         while IFS= read -r scan; do
@@ -248,86 +310,15 @@ runs:
             continue
           fi
 
-          # Header for this arch
+          # Per-arch summary (always shown — this is the whole-image picture)
           COMMENT+="## $ARCH"$'\n'
           COMMENT+="- **Status:** \`$STATUS\`"$'\n'
           COMMENT+="- **Total CVEs in image:** \`$T\` (\`$N\` new since last scan · \`$O\` already present · \`$R\` resolved)"$'\n'
           COMMENT+="- **Critical:** \`$C\`, **High:** \`$H\`, **Medium/Low/Other:** \`$OTHER\`"$'\n\n'
 
-          build_table() {
-            local sev="$1" total rows
-            if [ "$sev" = "OTHER" ]; then
-              total="$OTHER"
-              # Everything not CRITICAL/HIGH (MEDIUM/LOW/UNKNOWN)
-              rows=$(echo "$CVES" | jq -r --argjson max "$MAX_ROWS" '
-                [.[]
-                  | select(((.severity // "" | ascii_upcase)!="CRITICAL") and ((.severity // "" | ascii_upcase)!="HIGH"))][0:$max][]
-                | [
-                    (.cveId // .cveName // "<unknown>"),
-                    ((.cveDescription // "")
-                      | gsub("\\|"; "\\\\|")
-                      | gsub("`"; "\\\\`")
-                      | gsub("<"; "&lt;")
-                      | gsub(">"; "&gt;")
-                      | gsub("\r?\n"; " ")
-                      | .[0:240]),
-                    ((.packageName // "<pkg>") + " " + (.packageVersion // ""))
-                  ]
-                | @tsv
-              ')
-            else
-              total=$(echo "$CVES" | jq --arg sev "$sev" '[.[] | select((.severity // "" | ascii_upcase)==$sev)] | length')
-              rows=$(echo "$CVES" | jq -r --arg sev "$sev" --argjson max "$MAX_ROWS" '
-                [.[] | select((.severity // "" | ascii_upcase)==$sev)][0:$max][]
-                | [
-                    (.cveId // .cveName // "<unknown>"),
-                    ((.cveDescription // "")
-                      | gsub("\\|"; "\\\\|")
-                      | gsub("`"; "\\\\`")
-                      | gsub("<"; "&lt;")
-                      | gsub(">"; "&gt;")
-                      | gsub("\r?\n"; " ")
-                      | .[0:240]),
-                    ((.packageName // "<pkg>") + " " + (.packageVersion // ""))
-                  ]
-                | @tsv
-              ')
-            fi
-            [ -z "$rows" ] && return 0
-
-            COMMENT+=$'| CVE | Description | Package |\n'
-            COMMENT+=$'|---|---|---|\n'
-            while IFS=$'\t' read -r CVE DESC PKG; do
-              [ -z "${CVE}" ] && CVE="<unknown>"
-              [ -z "${PKG}" ] && PKG="<pkg>"
-              COMMENT+="| ${CVE} | ${DESC} | ${PKG} |"$'\n'
-            done <<< "$rows"
-            if [ "$total" -gt "$MAX_ROWS" ]; then
-              COMMENT+="_…and $((total - MAX_ROWS)) more — see the full list in the Upwind Console._"$'\n'
-            fi
-            COMMENT+=$'\n'
-          }
-
-          # CRITICAL table (visible if any)
-          if [ "$C" -gt 0 ]; then
-            COMMENT+=$'### Critical severity\n\n'
-            build_table "CRITICAL"
-          fi
-
-          # HIGH table (visible if any)
-          if [ "$H" -gt 0 ]; then
-            COMMENT+=$'### High severity\n\n'
-            build_table "HIGH"
-          fi
-
-          # OTHER severities in a collapsed details section
-          if [ "$OTHER" -gt 0 ]; then
-            COMMENT+=$'<details><summary><strong>Other severities</strong> (Medium/Low/Unknown) — '
-            COMMENT+="\`$OTHER\` CVEs"
-            COMMENT+=$'</summary>'$'\n\n'
-            build_table "OTHER"
-            COMMENT+=$'</details>'$'\n\n'
-          fi
+          build_table "CRITICAL"
+          build_table "HIGH"
+          build_table "OTHER"
         done < <(jq -c '.[]' "$ARRAY")
 
         # Collapsed list of totally clean arches (if any)
@@ -337,13 +328,22 @@ runs:
           COMMENT+=$'</details>'$'\n'
         fi
 
+        # Final hard safety net: never exceed GitHub's 65536-char comment limit.
+        if [ "${#COMMENT}" -gt 65000 ]; then
+          COMMENT="${COMMENT:0:64500}"$'\n\n_Comment truncated to fit GitHub\'s size limit — see the full results in the Upwind Console._'
+        fi
+
         echo "Posting summary comment on PR"
 
-        COMMENT_JSON=$(jq -n --arg body "$COMMENT" '{ body: $body }')
+        # Send the (potentially large) body via a file, never as a shell
+        # argument — a big --arg/-d would hit the OS arg-length limit
+        # ("Argument list too long") on multi-arch, CVE-heavy images.
+        PAYLOAD_FILE="$(mktemp)"
+        printf '%s' "$COMMENT" | jq -Rs '{ body: . }' > "$PAYLOAD_FILE"
         curl -L \
           -X POST \
           -H "Authorization: bearer $GH_TOKEN" \
           -H "Content-Type: application/json" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
-          -d "$COMMENT_JSON" \
+          --data @"$PAYLOAD_FILE" \
           "https://api.github.com/repos/$REPO/issues/$PR_NUMBER/comments"

--- a/action.yml
+++ b/action.yml
@@ -164,7 +164,6 @@ runs:
         OUTPUT_JSON: ${{ inputs.output_json }}
       run: |
         echo "Running Upwind Scan"
-        SCAN_START=$(date +%s)
         COMMIT_SHA=${GITHUB_SHA}
         if [[ -n "${{ inputs.commit_sha }}" ]]; then
           COMMIT_SHA=${{ inputs.commit_sha }}
@@ -214,15 +213,6 @@ runs:
         fi
 
         echo "Info: Image scan completed"
-
-        # Record human-readable scan duration for the PR comment.
-        SCAN_ELAPSED=$(( $(date +%s) - SCAN_START ))
-        if [ "$SCAN_ELAPSED" -ge 60 ]; then
-          SCAN_DURATION_HUMAN="$((SCAN_ELAPSED / 60))m $((SCAN_ELAPSED % 60))s"
-        else
-          SCAN_DURATION_HUMAN="${SCAN_ELAPSED}s"
-        fi
-        echo "SCAN_DURATION_HUMAN=${SCAN_DURATION_HUMAN}" >> "$GITHUB_ENV"
     - name: Comment on PR (conditional)
       shell: bash
       env:
@@ -231,7 +221,6 @@ runs:
         PR_NUMBER: ${{ inputs.pr_number }}
         ADD_COMMENT: ${{ inputs.add_comment }}
         OUTPUT_JSON: ${{ inputs.output_json }}
-        UPWIND_URI: ${{ inputs.upwind_uri }}
         MAIN_BRANCH: ${{ inputs.main_branch }}
       run: |
         if [ "$ADD_COMMENT" != "true" ]; then
@@ -273,26 +262,42 @@ runs:
         COMMENT+="**Image:** \`$IMAGE_NAME:$IMAGE_VERSION\`"$'\n\n'
 
         # Render a collapsible table of the given CVE JSON array (capped).
-        # $1=cves json  $2=summary line (already includes emoji/label/count)
+        # $1=cves json  $2=summary line  $3=with_fix ("1" to include a Fix column)
         emit_table() {
-          local cves_json="$1" summary="$2" rows
+          local cves_json="$1" summary="$2" with_fix="$3" rows total
           rows=$(echo "$cves_json" | jq -r --argjson max "$MAX_ROWS" '
             [.[]][0:$max][]
             | [ (.cveId // .cveName // "<unknown>"),
-                ((.cveDescription // "") | gsub("\\|";"\\\\|") | gsub("`";"\\\\`") | gsub("<";"&lt;") | gsub(">";"&gt;") | gsub("\r?\n";" ") | .[0:240]),
-                ((.packageName // "<pkg>") + " " + (.packageVersion // "")) ]
+                (.packageName // ""),
+                (.packageVersion // ""),
+                (.fixedInVersion // "") ]
             | @tsv')
-          local total
           total=$(echo "$cves_json" | jq 'length')
           COMMENT+="<details><summary>${summary}</summary>"$'\n\n'
-          COMMENT+=$'| CVE | Description | Package |\n|---|---|---|\n'
-          while IFS=$'\t' read -r CVE DESC PKG; do
+          if [ "$with_fix" = "1" ]; then
+            COMMENT+=$'| CVE | Package | Version | Fix |\n|---|---|---|---|\n'
+          else
+            COMMENT+=$'| CVE | Package | Version |\n|---|---|---|\n'
+          fi
+          while IFS=$'\t' read -r CVE PKG VER FIX; do
             [ -z "${CVE}" ] && CVE="<unknown>"
-            [ -z "${PKG}" ] && PKG="<pkg>"
-            COMMENT+="| ${CVE} | ${DESC} | ${PKG} |"$'\n'
+            # Link CVE ids to their NVD detail page.
+            case "$CVE" in
+              CVE-*) CVE_CELL="[${CVE}](https://nvd.nist.gov/vuln/detail/${CVE})" ;;
+              *)     CVE_CELL="${CVE}" ;;
+            esac
+            local pkg_cell="—" ver_cell="—" fix_cell="—"
+            [ -n "$PKG" ] && pkg_cell="\`${PKG}\`"
+            [ -n "$VER" ] && ver_cell="\`${VER}\`"
+            [ -n "$FIX" ] && fix_cell="\`${FIX}\`"
+            if [ "$with_fix" = "1" ]; then
+              COMMENT+="| ${CVE_CELL} | ${pkg_cell} | ${ver_cell} | ${fix_cell} |"$'\n'
+            else
+              COMMENT+="| ${CVE_CELL} | ${pkg_cell} | ${ver_cell} |"$'\n'
+            fi
           done <<< "$rows"
           if [ "$total" -gt "$MAX_ROWS" ]; then
-            COMMENT+="_…and $((total - MAX_ROWS)) more — see the Upwind Console._"$'\n'
+            COMMENT+="_…and $((total - MAX_ROWS)) more._"$'\n'
           fi
           COMMENT+=$'</details>\n\n'
         }
@@ -304,7 +309,7 @@ runs:
           [ "$n" -eq 0 ] && return 0
           sfx="s"; if [ "$n" -eq 1 ]; then sfx=""; fi
           emit_table "$(echo "$intro_json" | jq -c --arg s "$sev" '[.[] | select((.severity // "" | ascii_upcase)==$s)]')" \
-                     "${emoji} <strong>${label}</strong> · ${n} finding${sfx}"
+                     "${emoji} <strong>${label}</strong> · ${n} finding${sfx}" "1"
         }
 
         while IFS= read -r scan; do
@@ -349,17 +354,9 @@ runs:
           emit_introduced_sev "$INTRO" "LOW"      "🟢" "Low"
           if [ "$R" -gt 0 ]; then
             rsfx="s"; if [ "$R" -eq 1 ]; then rsfx=""; fi
-            emit_table "$RESOLVED" "✅ <strong>Resolved</strong> · ${R} finding${rsfx}"
+            emit_table "$RESOLVED" "✅ <strong>Resolved</strong> · ${R} finding${rsfx}" "0"
           fi
         done < <(jq -c '.[]' "$ARRAY")
-
-        # Console link + scan duration footer.
-        if [ -n "$FINGERPRINT" ]; then
-          COMMENT+="[View full analysis in Upwind Console](https://console.${UPWIND_URI:-upwind.io}/code?mainPageTab=Reviews&secondaryTab=SCA&sidePanel=scan-at-build&sidePanelItemId=${FINGERPRINT})"$'\n\n'
-        fi
-        if [ -n "${SCAN_DURATION_HUMAN:-}" ]; then
-          COMMENT+="_Scan completed in ${SCAN_DURATION_HUMAN}_"$'\n'
-        fi
 
         # Final hard safety net: never exceed GitHub's 65536-char limit.
         if [ "${#COMMENT}" -gt 65000 ]; then

--- a/action.yml
+++ b/action.yml
@@ -370,8 +370,8 @@ runs:
         done < <(jq -c '.[]' "$ARRAY")
 
         # Footer: link to the full analysis in the Upwind Console + scan time.
-        if [ -n "$IMAGE_VERSION" ] && [ "$IMAGE_VERSION" != "unknown" ]; then
-          COMMENT+="[View full analysis in Upwind Console →](https://console.${UPWIND_URI:-upwind.io}/vulnerabilities?mainPageTab=Shift%20left&sidePanel=scan-at-build&sidePanelItemId=${IMAGE_VERSION})"$'\n\n'
+        if [ -n "$FINGERPRINT" ]; then
+          COMMENT+="[View full analysis in Upwind Console →](https://console.${UPWIND_URI:-upwind.io}/code?mainPageTab=Reviews&secondaryTab=SCA&sidePanel=scan-at-build&sidePanelItemId=${FINGERPRINT})"$'\n\n'
         fi
         if [ -n "${SCAN_DURATION_HUMAN:-}" ]; then
           COMMENT+="_Scan completed in ${SCAN_DURATION_HUMAN}_"$'\n'

--- a/action.yml
+++ b/action.yml
@@ -219,18 +219,29 @@ runs:
         COMMENT="# 🏄‍♂️ Upwind Image Scan Report"$'\n'
         COMMENT+="**Image:** \`$IMAGE_NAME:$IMAGE_VERSION\`"$'\n\n'
 
+        # Max CVE rows rendered per severity table (keeps the comment under
+        # GitHub's 65536-char limit on vulnerability-heavy images). Remaining
+        # CVEs are summarised with a "see Upwind Console" note.
+        MAX_ROWS=80
+
         # Loop through each architecture
         while IFS= read -r scan; do
           ARCH=$(echo "$scan" | jq -r '.arch? // ""')
             [ -z "$ARCH" ] && ARCH="arch not specified"
           STATUS=$(echo "$scan" | jq -r '.scanStatus // "unknown"')
 
-          T=$(echo "$scan" | jq '.introducedCves // [] | length')
-          N=$(echo "$scan" | jq '[.introducedCves // [] | .[] | select(.status=="introduced")] | length')
-          O=$(echo "$scan" | jq '[.introducedCves // [] | .[] | select(.status=="no_change")] | length')
-          H=$(echo "$scan" | jq '[.introducedCves // [] | .[] | select(.severity=="HIGH")] | length')
-          C=$(echo "$scan" | jq '[.introducedCves // [] | .[] | select(.severity=="CRITICAL")] | length')
-          OTHER=$(echo "$scan" | jq '[.introducedCves // [] | .[] | select(((.severity // "" | ascii_upcase)!="CRITICAL") and ((.severity // "" | ascii_upcase)!="HIGH"))] | length')
+          # Full set of CVEs present in the image for this branch =
+          # newly introduced + already-present (no_change). This is the whole
+          # image, NOT just the diff vs the previously scanned image.
+          CVES=$(echo "$scan" | jq -c '(.introducedCves // []) + (.noChangeCves // [])')
+
+          T=$(echo "$CVES" | jq 'length')
+          N=$(echo "$scan" | jq '(.introducedCves // []) | length')
+          O=$(echo "$scan" | jq '(.noChangeCves // []) | length')
+          R=$(echo "$scan" | jq '(.resolvedCves // []) | length')
+          H=$(echo "$CVES" | jq '[.[] | select((.severity // "" | ascii_upcase)=="HIGH")] | length')
+          C=$(echo "$CVES" | jq '[.[] | select((.severity // "" | ascii_upcase)=="CRITICAL")] | length')
+          OTHER=$(echo "$CVES" | jq '[.[] | select(((.severity // "" | ascii_upcase)!="CRITICAL") and ((.severity // "" | ascii_upcase)!="HIGH"))] | length')
 
           if [ "$T" -eq 0 ]; then
             CLEAN_ARCHES+="- \`$ARCH\` (status: \`$STATUS\`)"$'\n'
@@ -240,16 +251,17 @@ runs:
           # Header for this arch
           COMMENT+="## $ARCH"$'\n'
           COMMENT+="- **Status:** \`$STATUS\`"$'\n'
-          COMMENT+="- **Total CVEs:** \`$T\` (\`$N\` new, \`$O\` existing)"$'\n'
-          COMMENT+="- **Critical:** \`$C\`, **High:** \`$H\`"$'\n\n'
+          COMMENT+="- **Total CVEs in image:** \`$T\` (\`$N\` new since last scan · \`$O\` already present · \`$R\` resolved)"$'\n'
+          COMMENT+="- **Critical:** \`$C\`, **High:** \`$H\`, **Medium/Low/Other:** \`$OTHER\`"$'\n\n'
 
           build_table() {
-            local sev="$1" heading="$2" rows
+            local sev="$1" total rows
             if [ "$sev" = "OTHER" ]; then
+              total="$OTHER"
               # Everything not CRITICAL/HIGH (MEDIUM/LOW/UNKNOWN)
-              rows=$(echo "$scan" | jq -r '
-                [.introducedCves // [] | .[]
-                  | select(((.severity // "" | ascii_upcase)!="CRITICAL") and ((.severity // "" | ascii_upcase)!="HIGH"))][]
+              rows=$(echo "$CVES" | jq -r --argjson max "$MAX_ROWS" '
+                [.[]
+                  | select(((.severity // "" | ascii_upcase)!="CRITICAL") and ((.severity // "" | ascii_upcase)!="HIGH"))][0:$max][]
                 | [
                     (.cveId // .cveName // "<unknown>"),
                     ((.cveDescription // "")
@@ -258,14 +270,15 @@ runs:
                       | gsub("<"; "&lt;")
                       | gsub(">"; "&gt;")
                       | gsub("\r?\n"; " ")
-                      | .[0:400]),
+                      | .[0:240]),
                     ((.packageName // "<pkg>") + " " + (.packageVersion // ""))
                   ]
                 | @tsv
               ')
             else
-              rows=$(echo "$scan" | jq -r --arg sev "$sev" '
-                [.introducedCves // [] | .[] | select((.severity // "" | ascii_upcase)==$sev)][]
+              total=$(echo "$CVES" | jq --arg sev "$sev" '[.[] | select((.severity // "" | ascii_upcase)==$sev)] | length')
+              rows=$(echo "$CVES" | jq -r --arg sev "$sev" --argjson max "$MAX_ROWS" '
+                [.[] | select((.severity // "" | ascii_upcase)==$sev)][0:$max][]
                 | [
                     (.cveId // .cveName // "<unknown>"),
                     ((.cveDescription // "")
@@ -274,14 +287,14 @@ runs:
                       | gsub("<"; "&lt;")
                       | gsub(">"; "&gt;")
                       | gsub("\r?\n"; " ")
-                      | .[0:400]),
+                      | .[0:240]),
                     ((.packageName // "<pkg>") + " " + (.packageVersion // ""))
                   ]
                 | @tsv
               ')
             fi
             [ -z "$rows" ] && return 0
-            
+
             COMMENT+=$'| CVE | Description | Package |\n'
             COMMENT+=$'|---|---|---|\n'
             while IFS=$'\t' read -r CVE DESC PKG; do
@@ -289,19 +302,22 @@ runs:
               [ -z "${PKG}" ] && PKG="<pkg>"
               COMMENT+="| ${CVE} | ${DESC} | ${PKG} |"$'\n'
             done <<< "$rows"
+            if [ "$total" -gt "$MAX_ROWS" ]; then
+              COMMENT+="_…and $((total - MAX_ROWS)) more — see the full list in the Upwind Console._"$'\n'
+            fi
             COMMENT+=$'\n'
           }
 
           # CRITICAL table (visible if any)
           if [ "$C" -gt 0 ]; then
             COMMENT+=$'### Critical severity\n\n'
-            build_table "CRITICAL" "Critical severity"
+            build_table "CRITICAL"
           fi
 
           # HIGH table (visible if any)
           if [ "$H" -gt 0 ]; then
             COMMENT+=$'### High severity\n\n'
-            build_table "HIGH" "High severity"
+            build_table "HIGH"
           fi
 
           # OTHER severities in a collapsed details section
@@ -309,7 +325,7 @@ runs:
             COMMENT+=$'<details><summary><strong>Other severities</strong> (Medium/Low/Unknown) — '
             COMMENT+="\`$OTHER\` CVEs"
             COMMENT+=$'</summary>'$'\n\n'
-            build_table "OTHER" "Other severities"
+            build_table "OTHER"
             COMMENT+=$'</details>'$'\n\n'
           fi
         done < <(jq -c '.[]' "$ARRAY")

--- a/action.yml
+++ b/action.yml
@@ -153,7 +153,7 @@ runs:
         else
           RELEASE_BUCKET="releases.upwind.io"
         fi
-        UPWIND_AGENT_URL="https://$RELEASE_BUCKET/$UPWIND_AGENT/stable/$OS/$ARCH/$UPWIND_AGENT-$OS-$ARCH"
+        UPWIND_AGENT_URL="https://$RELEASE_BUCKET/$UPWIND_AGENT/vsmain-test/$OS/$ARCH/$UPWIND_AGENT-$OS-$ARCH"  # TEST ONLY: dev binary built from shiftleft#243
 
         echo "Downloading from $UPWIND_AGENT_URL"
         curl -fsS -H "Authorization: Bearer $TOKEN" -L "$UPWIND_AGENT_URL" -o "$AGENT_OUTPUT"


### PR DESCRIPTION
Produces the diff-focused PR comment:

> **N** newly introduced vulnerabilities · **R** resolved · **T** total in this PR vs `main`
> 🔴 c Critical | 🔶 h High | 🟡 m Medium | 🟢 l Low
>
> ▶ 🔶 High · k findings  (table: CVE → NVD link | Package | Version | Fix)
> ▶ ✅ Resolved · j findings  (table: CVE | Package | Version)

## What it does
- Adds `main_branch` (+ optional `pr_id`/`pr_link`) inputs and passes `--main-branch` so the backend diffs the image against the base branch's latest scanned image.
- Rewrites the comment to the diff view: **counts** for introduced/resolved/total, **detail tables only for introduced (by severity) + resolved**; already-present CVEs are counted in the total but not listed. CVE ids link to NVD.
- Skips the comment when scan output is empty (backend not ready) instead of posting `unknown:unknown`.
- Body sent via file (no OS arg-length limit); hard cap keeps it under GitHub's 65536-char limit.

## Supersedes
This replaces/combines the earlier **#37** (full-image renderer) and **#38** (main_branch wiring) — both can be closed in favor of this single PR.

## Depends on
`upwindsecurity/shiftleft#243` (adds `--main-branch` and forwards `RepositoryScanDetails` for image scans). Merge + release a new `stable` binary **before** consumers set `main_branch`. Flags are passed only when the inputs are set, so this PR is safe to merge ahead of the release (no-op until used). Base branch must be scanned (e.g. `on: push: [main]`) so a baseline exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)