### PR TITLE
feat(UP-2638): expose result_wait_seconds (default 300s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Define the following inputs in your workflow to configure the action:
 | `main_branch`                          | No       | –               | Base/target branch to diff against (typically `github.event.pull_request.base.ref`). When set, introduced/resolved CVEs are computed against the latest scanned image of this branch instead of the previous scan. Requires that branch to have been scanned. |
 | `pr_id`                                | No       | –               | Pull request identifier to associate with the scan.                                                                                 |
 | `pr_link`                              | No       | –               | Pull request URL to associate with the scan.                                                                                        |
+| `result_wait_seconds`                  | No       | `300`           | Seconds the CLI waits for scan results before giving up (results not ready ⇒ the PR comment is skipped).                            |
 
 Sensitive values such as `upwind_client_id`, `upwind_client_secret`, and `docker_password` should be stored securely using GitHub Secrets.
 

--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,10 @@ inputs:
     description: File location to write JSON output to
     default: "output.json"
     type: string
+  result_wait_seconds:
+    description: How long (in seconds) the CLI waits for scan results before giving up. When results aren't ready in time the PR comment is skipped.
+    default: "300"
+    type: string
   commit_sha:
     description: SHA to be associated with the build. By default this uses the $GITHUB_SHA environmental variable
     default: ${GITHUB_SHA}
@@ -209,6 +213,7 @@ runs:
           --oci-client=${{ inputs.oci_client }} \
           --block-on="${{ inputs.block_on}}" \
           --should-perform-multi-platform-scan=${{ inputs.perform_multiarchitecture_image_scan}} \
+          --result-wait-seconds=${{ inputs.result_wait_seconds }} \
           "${EXTRA_ARGS[@]}"
         if [ ! -f "$OUTPUT_JSON" ]; then
           echo "Error: $OUTPUT_JSON not found"


### PR DESCRIPTION
## Why
Client-side insurance for Pylon #10216 / UP-2638: the `shiftleft` CLI's `--result-wait-seconds` default (60s) is shorter than the observed backend SBOM ingestion tail, so the result poll times out and the action posts an empty / skipped PR comment.

## What
Exposes the CLI's existing `--result-wait-seconds` flag as a new action input `result_wait_seconds`, default **300s**. Covers the observed 60–433s ingestion tail. Adds a README inputs-table row.

Server-side fix (short requeue that kills the 600s redelivery tail) lands separately in `shiftleft-processor` (#115).

## Testing
`action.yml` validates as YAML; the flag is appended inside the `./shiftleft image` command with the backslash-continuation chain intact and no existing flag disturbed.